### PR TITLE
modify kiosk mode for removing panel options from iframe

### DIFF
--- a/public/sass/components/_view_states.scss
+++ b/public/sass/components/_view_states.scss
@@ -6,6 +6,11 @@
   .scroll-canvas--dashboard {
     height: 100%;
   }
+  .panel-menu-container,
+  .panel-info-corner--info,
+  .panel-info-corner--links {
+    display: none;
+  }
 }
 
 .playlist-active,

--- a/public/sass/components/_view_states.scss
+++ b/public/sass/components/_view_states.scss
@@ -6,6 +6,7 @@
   .scroll-canvas--dashboard {
     height: 100%;
   }
+  // remove panel dropdown option
   .panel-menu-container,
   .panel-info-corner--info,
   .panel-info-corner--links {


### PR DESCRIPTION
This pr modifies kiosk (query param) mode view for removing the panel dropdown option in iframe view of panels. 
