### PR TITLE
Add a new query param

### DIFF
--- a/public/app/core/components/grafana_app.ts
+++ b/public/app/core/components/grafana_app.ts
@@ -117,6 +117,11 @@ export function grafanaAppDirective(playlistSrv, contextSrv, $timeout, $rootScop
           appEvents.emit('toggle-kiosk-mode');
         }
 
+        //handle submenu url param
+        if (data.params.submenu) {
+          appEvents.emit('toggle-submenu-mode');
+        }
+
         // check for 'inactive' url param for clean looks like kiosk, but with title
         if (data.params.inactive) {
           body.addClass('user-activity-low');
@@ -134,6 +139,11 @@ export function grafanaAppDirective(playlistSrv, contextSrv, $timeout, $rootScop
       // handle kiosk mode
       appEvents.on('toggle-kiosk-mode', () => {
         body.toggleClass('page-kiosk-mode');
+      });
+
+      //handle submenu mode. It shows the submenu and the time picker and zoom button
+      appEvents.on('toggle-submenu-mode', () => {
+        body.toggleClass('page-submenu-mode');
       });
 
       // handle in active view state class

--- a/public/app/features/dashboard/dashnav/dashnav.html
+++ b/public/app/features/dashboard/dashnav/dashnav.html
@@ -42,7 +42,7 @@
 		</button>
 	</div>
 
-	<gf-time-picker class="gf-timepicker-nav" dashboard="ctrl.dashboard" ng-if="!ctrl.dashboard.timepicker.hidden"></gf-time-picker>
+	<!--<gf-time-picker class="gf-timepicker-nav" dashboard="ctrl.dashboard" ng-if="!ctrl.dashboard.timepicker.hidden"></gf-time-picker> -->
 
 	<div class="navbar-buttons navbar-buttons--close">
 		<button class="btn navbar-button navbar-button--primary" ng-click="ctrl.close()" bs-tooltip="'Back to dashboard'" data-placement="bottom">

--- a/public/app/features/dashboard/submenu/submenu.html
+++ b/public/app/features/dashboard/submenu/submenu.html
@@ -18,6 +18,8 @@
   <div class="gf-form gf-form--grow">
   </div>
 
+  <gf-time-picker class="gf-timepicker-nav" style="z-index: 100;" dashboard="ctrl.dashboard" ng-if="!ctrl.dashboard.timepicker.hidden"></gf-time-picker>
+  
   <div ng-if="ctrl.dashboard.links.length > 0" >
     <dash-links-container links="ctrl.dashboard.links" class="gf-form-inline"></dash-links-container>
   </div>

--- a/public/sass/components/_view_states.scss
+++ b/public/sass/components/_view_states.scss
@@ -1,8 +1,5 @@
 .page-kiosk-mode {
   .sidemenu,
-  .navbar {
-    display: none;
-  }
   .scroll-canvas--dashboard {
     height: 100%;
   }
@@ -10,6 +7,32 @@
   .panel-menu-container,
   .panel-info-corner--info,
   .panel-info-corner--links {
+    display: none;
+  }
+
+  // remove nav-bar
+  .navbar {
+    display: none;
+  }
+  .submenu-controls {
+    display: none;
+  }
+}
+
+.page-submenu-mode {
+  .sidemenu,
+  .scroll-canvas--dashboard {
+    height: 100%;
+  }
+  // remove panel dropdown option
+  .panel-menu-container,
+  .panel-info-corner--info,
+  .panel-info-corner--links {
+    display: none;
+  }
+
+  // remove nav-bar
+  .navbar {
     display: none;
   }
 }


### PR DESCRIPTION
This pr adds a new query param 'submenu' which when passed in url hides the top navigation bar and shows the submenu(templating variable) and zoom, timepicker and refresh button in the same line.
Files modified -->
        modified:   public/app/core/components/grafana_app.ts
	modified:   public/app/features/dashboard/dashnav/dashnav.html
	modified:   public/app/features/dashboard/submenu/submenu.html
	modified:   public/sass/components/_view_states.scss

Signed-off-by: meghna <singhmeghna79@gmail.com>

