### PR TITLE
fix unauthorized issue

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -100,6 +100,9 @@ server_cert_name =
 # For "sqlite3" only, path relative to data_path setting
 path = grafana.db
 
+# For "sqlite3" only. cache mode setting used for connecting to the database
+cache_mode = private
+
 #################################### Session #############################
 [session]
 # Either "memory", "file", "redis", "mysql", "postgres", "memcache", default is "file"

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -84,6 +84,9 @@
 # For "sqlite3" only, path relative to data_path setting
 ;path = grafana.db
 
+# For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
+;cache_mode = private
+
 # Max idle conn setting default is 2
 ;max_idle_conn = 2
 

--- a/docs/sources/installation/configuration.md
+++ b/docs/sources/installation/configuration.md
@@ -242,6 +242,12 @@ Sets the maximum amount of time a connection may be reused. The default is 14400
 
 Set to `true` to log the sql calls and execution times.
 
+### cache_mode
+  
+For "sqlite3" only. [Shared cache](https://www.sqlite.org/sharedcache.html) setting used for connecting to the database. (private, shared)
+Defaults to private.
+  
+
 <hr />
 
 ## [security]

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -37,6 +37,7 @@ type DatabaseConfig struct {
 	MaxOpenConn                                int
 	MaxIdleConn                                int
 	ConnMaxLifetime                            int
+	CacheMode                                  string
 }
 
 var (
@@ -152,7 +153,7 @@ func getEngine() (*xorm.Engine, error) {
 			DbCfg.Path = filepath.Join(setting.DataPath, DbCfg.Path)
 		}
 		os.MkdirAll(path.Dir(DbCfg.Path), os.ModePerm)
-		cnnstr = "file:" + DbCfg.Path
+		cnnstr = fmt.Sprintf("file:%s?cache=%s&mode=rwc", DbCfg.Path, DbCfg.CacheMode)
 	default:
 		return nil, fmt.Errorf("Unknown database type: %s", DbCfg.Type)
 	}
@@ -222,6 +223,7 @@ func LoadConfig() {
 	DbCfg.ClientCertPath = sec.Key("client_cert_path").String()
 	DbCfg.ServerCertName = sec.Key("server_cert_name").String()
 	DbCfg.Path = sec.Key("path").MustString("data/grafana.db")
+	DbCfg.CacheMode = sec.Key("cache_mode").MustString("private")
 }
 
 var (


### PR DESCRIPTION
This pr a try fix for  the unauthorized issue which is probably due to using sqlite database. Unauthorized error occurs when  loading a dashboard and then waiting for an auto-refresh. It doesn't happen on every auto-refresh, and sometimes it can trigger with a manual click of the dashboard refresh button (the one built into Grafana, not the browser refresh button) but generally it seems to happen more often when the user is inactive (leaving grafana in a background tab, for example.)

Reason suspected is 
```
I looked into it some more and there are multiple problems here:

go-sqlite is not known to be goroutine-safe (which makes this whole thing with a central xorm-managed connection possibly a bad idea).
SQLite does not support concurrent queries on a single "connection". We'd need to get xorm to open multiple connections to SQLite. Otherwise we might run into deadlocks or these locking errors since SQLite will not try to resolve locks if they are from the same connection.
I've seen people do multiple things to avoid these SQLite issues, including wrapping all SQLite access in a single mutex and opening a new SQLite instance per request. The easiest thing to do is probably to hack go-sqlite3 to contain a mutex per "connection" and just serialize all access to it (EDIT: Just realized this probably won't work since the locks show up when reading from a cursor, which you can't lock on without risking deadlocks). That's the way a C program would do it (which SQLite was made for). It might be slow, but people who need the performance should go to PostgreSQL anyways.
```
Found this from grafana issues (issue no. 10727)

FIles changed -->
        modified:   conf/defaults.ini
	modified:   conf/sample.ini
	modified:   docs/sources/installation/configuration.md
	modified:   pkg/services/sqlstore/sqlstore.go



